### PR TITLE
Add Colmap OpenCV Camera Model and Enhance Principal Point Handling

### DIFF
--- a/gaustudio/datasets/__init__.py
+++ b/gaustudio/datasets/__init__.py
@@ -105,8 +105,8 @@ class Camera:
 
     world_view_transform: torch.tensor = None 
     full_proj_transform: torch.tensor = None
-    camera_center: torch.tensor = None
-    principal_point_ndc: np.array([0.5, 0.5])
+    camera_center: torch.tensor = None    
+    principal_point_ndc: np.array = np.array([0.5, 0.5])
     
     image_path: str = None
     image_name: str = None
@@ -131,7 +131,7 @@ class Camera:
             self.image = torch.from_numpy(np.array(Image.open(self.image_path).convert("RGB"))) / 255.0
             self.image_name = os.path.basename(self.image_path).split(".")[0]
             self.image_height, self.image_width, _ = self.image.shape
-
+        print(self.principal_point_ndc)
         # Compute camera center from inverse view matrix
         view_inv = torch.inverse(self.world_view_transform)
         self.camera_center = view_inv[3][:3]

--- a/gaustudio/datasets/__init__.py
+++ b/gaustudio/datasets/__init__.py
@@ -106,7 +106,7 @@ class Camera:
     world_view_transform: torch.tensor = None 
     full_proj_transform: torch.tensor = None
     camera_center: torch.tensor = None
-    principal_point_ndc: np.array = None
+    principal_point_ndc: np.array([0.5, 0.5])
     
     image_path: str = None
     image_name: str = None
@@ -159,8 +159,8 @@ class Camera:
         tan_fovy = np.tan(self.FoVy / 2.0)
         focal_y = self.image_height / (2.0 * tan_fovy)
         focal_x = self.image_width / (2.0 * tan_fovx)
-        return torch.tensor([[focal_x, 0, self.image_width / 2], 
-                             [0, focal_y, self.image_height / 2], 
+        return torch.tensor([[focal_x, 0, self.image_width * principal_point_ndc[0]], 
+                             [0, focal_y, self.image_height * principal_point_ndc[1]], 
                              [0, 0, 1]]).float()
      
     @extrinsics.setter

--- a/gaustudio/datasets/colmap.py
+++ b/gaustudio/datasets/colmap.py
@@ -68,11 +68,15 @@ class ColmapDatasetBase:
                 focal_length_x = intr.params[0]
                 FoVy = focal2fov(focal_length_x, height)
                 FoVx = focal2fov(focal_length_x, width)
+                cx = intr.params[1]
+                cy = intr.params[2]
             elif intr.model=="PINHOLE":
                 focal_length_x = intr.params[0]
                 focal_length_y = intr.params[1]
                 FoVy = focal2fov(focal_length_y, height)
                 FoVx = focal2fov(focal_length_x, width)
+                cx = intr.params[2]
+                cy = intr.params[3]
             else:
                 assert False, "Colmap camera model not handled: only undistorted datasets (PINHOLE or SIMPLE_PINHOLE cameras) supported!"
 
@@ -109,7 +113,8 @@ class ColmapDatasetBase:
                 else:
                     bg_image_tensor = torch.zeros((height, width, 3))
                 _camera = datasets.Camera(R=R, T=T, FoVy=FoVy, FoVx=FoVx, image_path=image_path, 
-                                          image_width=width, image_height=height, bg_image=bg_image_tensor)
+                                          image_width=width, image_height=height, bg_image=bg_image_tensor,
+                                          principal_point_ndc=np.array([cx / width, cy /height]))
             all_cameras_unsorted.append(_camera)
 
         self.all_cameras = sorted(all_cameras_unsorted, key=lambda x: x.image_name) 

--- a/gaustudio/datasets/colmap.py
+++ b/gaustudio/datasets/colmap.py
@@ -6,9 +6,8 @@ from torch.utils.data import Dataset, DataLoader
 
 import os
 import cv2
-import sys
 import json
-
+import warnings
 import numpy as np
 from PIL import Image
 from typing import List, Dict 
@@ -70,7 +69,13 @@ class ColmapDatasetBase:
                 FoVx = focal2fov(focal_length_x, width)
                 cx = intr.params[1]
                 cy = intr.params[2]
-            elif intr.model=="PINHOLE":
+            elif intr.model=="PINHOLE" or intr.model=="OPENCV":
+                if intr.model == "OPENCV":
+                    warnings.warn(
+                        "OpenCV camera model detected. Distortion parameters will be discarded, which may degrade image quality. "
+                        "It is recommended to run undistortion on your images before proceeding.",
+                        UserWarning
+                    )
                 focal_length_x = intr.params[0]
                 focal_length_y = intr.params[1]
                 FoVy = focal2fov(focal_length_y, height)

--- a/gaustudio/datasets/deepvoxels.py
+++ b/gaustudio/datasets/deepvoxels.py
@@ -49,7 +49,9 @@ class DeepVoxelsDatasetBase:
             
             FoVy = focal2fov(fy, height)
             FoVx = focal2fov(fx, width)
-            _camera = datasets.Camera(R=R, T=T, FoVy=FoVy, FoVx=FoVx, image_path=image_path, image_width=width, image_height=height)
+            _camera = datasets.Camera(R=R, T=T, FoVy=FoVy, FoVx=FoVx, image_path=image_path, 
+                                      image_width=width, image_height=height,
+                                      principal_point_ndc=np.array([cx / width, cy /height]))
             all_cameras_unsorted.append(_camera)
         self.all_cameras = sorted(all_cameras_unsorted, key=lambda x: x.image_name) 
         self.nerf_normalization = getNerfppNorm(self.all_cameras)

--- a/gaustudio/datasets/mobilebrick.py
+++ b/gaustudio/datasets/mobilebrick.py
@@ -62,10 +62,10 @@ class MobileBrickDatasetBase:
                 background = cv2.bitwise_and(black_background, black_background, mask=background_mask)
                 masked_image = cv2.bitwise_and(_image, _image, mask=mask)
                 _image = cv2.addWeighted(masked_image, 1, background, 1, 0)
+                _mask_tensor = torch.from_numpy(mask)
             else:
-                mask = None
+                _mask_tensor = None
             _image_tensor = torch.from_numpy(cv2.cvtColor(_image, cv2.COLOR_BGR2RGB)).float() / 255
-            _mask_tensor = torch.from_numpy(mask)
             _camera = datasets.Camera(R=R, T=T, FoVy=FoVy, FoVx=FoVx, image=_image_tensor, image_name=image_name, 
                                       image_width=width, image_height=height, mask=_mask_tensor,
                                       principal_point_ndc=np.array([cx / width, cy /height]))

--- a/gaustudio/datasets/mvsnet.py
+++ b/gaustudio/datasets/mvsnet.py
@@ -84,7 +84,9 @@ class MvsnetDatasetBase:
             
             FoVy = focal2fov(fy, height)
             FoVx = focal2fov(fx, width)
-            _camera = datasets.Camera(R=R, T=T, FoVy=FoVy, FoVx=FoVx, image_path=image_path, image_width=width, image_height=height)
+            _camera = datasets.Camera(R=R, T=T, FoVy=FoVy, FoVx=FoVx, 
+                                      image_path=image_path, image_width=width, image_height=height,
+                                      principal_point_ndc=np.array([cx / width, cy /height]))
             all_cameras_unsorted.append(_camera)
         self.all_cameras = sorted(all_cameras_unsorted, key=lambda x: x.image_name) 
         self.nerf_normalization = getNerfppNorm(self.all_cameras)

--- a/gaustudio/datasets/nerfstudio.py
+++ b/gaustudio/datasets/nerfstudio.py
@@ -47,7 +47,9 @@ class NerfStudioDatasetBase:
             R = np.transpose(extrinsics[:3, :3])
             T = extrinsics[:3, 3]
             
-            _camera = datasets.Camera(R=R, T=T, FoVy=FoVy, FoVx=FoVx, image_path=image_path, image_width=width, image_height=height)
+            _camera = datasets.Camera(R=R, T=T, FoVy=FoVy, FoVx=FoVx, image_path=image_path, 
+                                      image_width=width, image_height=height,
+                                      principal_point_ndc=np.array([cx / width, cy /height]))
             all_cameras_unsorted.append(_camera)
         self.all_cameras = sorted(all_cameras_unsorted, key=lambda x: x.image_name) 
         self.nerf_normalization = getNerfppNorm(self.all_cameras)

--- a/gaustudio/datasets/nero.py
+++ b/gaustudio/datasets/nero.py
@@ -53,7 +53,9 @@ class NeRODatasetBase:
             
             FoVy = focal2fov(fy, height)
             FoVx = focal2fov(fx, width)
-            _camera = datasets.Camera(R=R, T=T, FoVy=FoVy, FoVx=FoVx, image_path=image_path, image_width=width, image_height=height)
+            _camera = datasets.Camera(R=R, T=T, FoVy=FoVy, FoVx=FoVx, image_path=image_path, 
+                                      image_width=width, image_height=height,
+                                      principal_point_ndc=np.array([cx / width, cy /height]))
             all_cameras_unsorted.append(_camera)
         self.all_cameras = sorted(all_cameras_unsorted, key=lambda x: x.image_name) 
         self.nerf_normalization = getNerfppNorm(self.all_cameras)

--- a/gaustudio/datasets/neus.py
+++ b/gaustudio/datasets/neus.py
@@ -73,7 +73,6 @@ class NeusDatasetBase:
             P = (world_mat @ scale_mat)[:3,:4]
             K, c2w = load_K_Rt_from_P(P)
             fx, fy, cx, cy = K[0,0], K[1,1], K[0,2], K[1,2]
-
             extrinsics = np.linalg.inv(c2w)
             R = np.transpose(extrinsics[:3, :3])
             T = extrinsics[:3, 3]
@@ -82,7 +81,9 @@ class NeusDatasetBase:
             FoVx = focal2fov(fx, width)
             _image_tensor = torch.from_numpy(cv2.cvtColor(_image, cv2.COLOR_BGR2RGB)).float() / 255
             _mask_tensor = torch.from_numpy(mask) if mask is not None else None
-            _camera = datasets.Camera(R=R, T=T, FoVy=FoVy, FoVx=FoVx, image=_image_tensor, image_name=image_name, image_width=width, image_height=height, mask=_mask_tensor)
+            _camera = datasets.Camera(R=R, T=T, FoVy=FoVy, FoVx=FoVx, image=_image_tensor, 
+                                      image_name=image_name, image_width=width, image_height=height, 
+                                      mask=_mask_tensor, principal_point_ndc=np.array([cx / width, cy /height]))
             all_cameras_unsorted.append(_camera)
         self.all_cameras = sorted(all_cameras_unsorted, key=lambda x: x.image_name) 
         self.nerf_normalization = getNerfppNorm(self.all_cameras)

--- a/gaustudio/datasets/nsvf.py
+++ b/gaustudio/datasets/nsvf.py
@@ -52,7 +52,9 @@ class NSVFDatasetBase:
             
             FoVy = focal2fov(fy, height)
             FoVx = focal2fov(fx, width)
-            _camera = datasets.Camera(R=R, T=T, FoVy=FoVy, FoVx=FoVx, image_path=image_path, image_width=width, image_height=height)
+            _camera = datasets.Camera(R=R, T=T, FoVy=FoVy, FoVx=FoVx, image_path=image_path, 
+                                      image_width=width, image_height=height,
+                                      principal_point_ndc=np.array([cx / width, cy /height]))
             all_cameras_unsorted.append(_camera)
         self.all_cameras = sorted(all_cameras_unsorted, key=lambda x: x.image_name) 
         self.nerf_normalization = getNerfppNorm(self.all_cameras)

--- a/gaustudio/datasets/polycam.py
+++ b/gaustudio/datasets/polycam.py
@@ -56,7 +56,9 @@ class PolycamDatasetBase:
             
             FoVy = focal2fov(fy, height)
             FoVx = focal2fov(fx, width)
-            _camera = datasets.Camera(R=R, T=T, FoVy=FoVy, FoVx=FoVx, image_path=image_path, image_width=width, image_height=height)
+            _camera = datasets.Camera(R=R, T=T, FoVy=FoVy, FoVx=FoVx, image_path=image_path, 
+                                      image_width=width, image_height=height,
+                                      principal_point_ndc=np.array([cx / width, cy /height]))
             all_cameras_unsorted.append(_camera)
         self.all_cameras = sorted(all_cameras_unsorted, key=lambda x: x.image_name) 
         self.nerf_normalization = getNerfppNorm(self.all_cameras)

--- a/gaustudio/datasets/scannet.py
+++ b/gaustudio/datasets/scannet.py
@@ -45,7 +45,9 @@ class ScannetDatasetBase:
             
             FoVy = focal2fov(fy, height)
             FoVx = focal2fov(fx, width)
-            _camera = datasets.Camera(R=R, T=T, FoVy=FoVy, FoVx=FoVx, image_path=image_path, image_width=width, image_height=height)
+            _camera = datasets.Camera(R=R, T=T, FoVy=FoVy, FoVx=FoVx, image_path=image_path, 
+                                      image_width=width, image_height=height,
+                                      principal_point_ndc=np.array([cx / width, cy /height]))
             all_cameras_unsorted.append(_camera)
         self.all_cameras = sorted(all_cameras_unsorted, key=lambda x: x.image_name) 
         self.nerf_normalization = getNerfppNorm(self.all_cameras)

--- a/gaustudio/datasets/utils.py
+++ b/gaustudio/datasets/utils.py
@@ -42,7 +42,7 @@ def camera_to_JSON(id, camera : datasets.Camera):
         'rotation': serializable_array_2d,
         'fy' : fov2focal(camera.FoVy, camera.image_height),
         'fx' : fov2focal(camera.FoVx, camera.image_width),
-        'cy' : camera.image_height * principal_point_ndc[1],
+        'cy' : camera.image_height * camera.principal_point_ndc[1],
         'cx' : camera.image_width * camera.principal_point_ndc[0]
     }
     return camera_entry

--- a/gaustudio/datasets/utils.py
+++ b/gaustudio/datasets/utils.py
@@ -41,7 +41,9 @@ def camera_to_JSON(id, camera : datasets.Camera):
         'position': pos.tolist(),
         'rotation': serializable_array_2d,
         'fy' : fov2focal(camera.FoVy, camera.image_height),
-        'fx' : fov2focal(camera.FoVx, camera.image_width)
+        'fx' : fov2focal(camera.FoVx, camera.image_width),
+        'cy' : camera.image_height * principal_point_ndc[1],
+        'cx' : camera.image_width * camera.principal_point_ndc[0]
     }
     return camera_entry
 

--- a/gaustudio/datasets/waymo.py
+++ b/gaustudio/datasets/waymo.py
@@ -104,7 +104,9 @@ class WaymoDatasetBase:
                 
                 FoVy = focal2fov(fy, height)
                 FoVx = focal2fov(fx, width)
-                _camera = datasets.Camera(R=R, T=T, FoVy=FoVy, FoVx=FoVx, image_path=temp_image_path, image_width=width, image_height=height)
+                _camera = datasets.Camera(R=R, T=T, FoVy=FoVy, FoVx=FoVx, image_path=temp_image_path, 
+                                          image_width=width, image_height=height,
+                                          principal_point_ndc=np.array([cx / width, cy /height]))
                 all_cameras_unsorted.append(_camera)
         self.all_cameras = sorted(all_cameras_unsorted, key=lambda x: x.image_name) 
         self.nerf_normalization = getNerfppNorm(self.all_cameras)

--- a/gaustudio/utils/graphics_utils.py
+++ b/gaustudio/utils/graphics_utils.py
@@ -50,13 +50,7 @@ def depth2point(depth_image, intrinsic_matrix, extrinsic_matrix):
 def depths_to_points(view, depthmap):
     c2w = (view.world_view_transform.T).inverse()
     W, H = view.image_width, view.image_height
-    fx = W / (2 * math.tan(view.FoVx / 2.))
-    fy = H / (2 * math.tan(view.FoVy / 2.))
-    intrins = torch.tensor(
-        [[fx, 0., W/2.],
-        [0., fy, H/2.],
-        [0., 0., 1.0]]
-    ).float().cuda()
+    intrins = view.intrinsics.cuda()
     grid_x, grid_y = torch.meshgrid(torch.arange(W, device='cuda').float(), torch.arange(H, device='cuda').float(), indexing='xy')
     points = torch.stack([grid_x, grid_y, torch.ones_like(grid_x)], dim=-1).reshape(-1, 3)
     rays_d = points @ intrins.inverse().T @ c2w[:3,:3].T


### PR DESCRIPTION
1. Implement support for Colmap OpenCV camera model
2. Add principal point (cx, cy) loading for 13 datasets
3. Update projection matrix calculation (thanks to @leonwu0108 and @hbb1's valuable discussion and code: https://github.com/hbb1/2d-gaussian-splatting/pull/74)
4. Implement cx, cy export functionality
5. Integrate principal point support in various operations:
   - TSDF fusion
   - Depth normal calculation
   - Mesh Rendering
