### PR TITLE
fix: fix gcc13 build error

### DIFF
--- a/submodules/gaustudio-diff-gaussian-rasterization/cuda_rasterizer/rasterizer_impl.h
+++ b/submodules/gaustudio-diff-gaussian-rasterization/cuda_rasterizer/rasterizer_impl.h
@@ -14,6 +14,7 @@
 #include <iostream>
 #include <vector>
 #include "rasterizer.h"
+#include <cstdint>
 #include <cuda_runtime_api.h>
 
 namespace CudaRasterizer


### PR DESCRIPTION
When using gcc 13, it will have following errors:
```bash
❯ pip install submodules/gaustudio-diff-gaussian-rasterization 
Looking in indexes: https://mirrors.ustc.edu.cn/pypi/web/simple
Processing ./submodules/gaustudio-diff-gaussian-rasterization
  Preparing metadata (setup.py) ... done
Building wheels for collected packages: gaustudio_diff_gaussian_rasterization
  Building wheel for gaustudio_diff_gaussian_rasterization (setup.py) ... error
  error: subprocess-exited-with-error
  
  × python setup.py bdist_wheel did not run successfully.
  │ exit code: 1
  ╰─> [75 lines of output]
      running bdist_wheel
      /data1/home/lucky/anaconda3/envs/sugar/lib/python3.9/site-packages/torch/utils/cpp_extension.py:499: UserWarning: Attempted to use ninja as the BuildExtension backend but we could not find ninja.. Falling back to using the slow distutils backend.
        warnings.warn(msg.format('we could not find ninja.'))
      running build
      running build_py
      creating build
      creating build/lib.linux-x86_64-cpython-39
      creating build/lib.linux-x86_64-cpython-39/gaustudio_diff_gaussian_rasterization
      copying gaustudio_diff_gaussian_rasterization/__init__.py -> build/lib.linux-x86_64-cpython-39/gaustudio_diff_gaussian_rasterization
      running build_ext
      /data1/home/lucky/anaconda3/envs/sugar/lib/python3.9/site-packages/torch/utils/cpp_extension.py:418: UserWarning: The detected CUDA version (12.5) has a minor version mismatch with the version that was used to compile PyTorch (12.1). Most likely this shouldn't be a problem.
        warnings.warn(CUDA_MISMATCH_WARN.format(cuda_str_version, torch.version.cuda))
      /data1/home/lucky/anaconda3/envs/sugar/lib/python3.9/site-packages/torch/utils/cpp_extension.py:428: UserWarning: There are no g++ version bounds defined for CUDA version 12.5
        warnings.warn(f'There are no {compiler_name} version bounds defined for CUDA version {cuda_str_version}')
      building 'gaustudio_diff_gaussian_rasterization._C' extension
      creating build/temp.linux-x86_64-cpython-39
      creating build/temp.linux-x86_64-cpython-39/cuda_rasterizer
      /data1/home/lucky/anaconda3/envs/sugar/lib/python3.9/site-packages/torch/utils/cpp_extension.py:1967: UserWarning: TORCH_CUDA_ARCH_LIST is not set, all archs for visible cards are included for compilation.
      If this is not desired, please set os.environ['TORCH_CUDA_ARCH_LIST'].
        warnings.warn(
      /opt/cuda/bin/nvcc -I/data1/home/lucky/anaconda3/envs/sugar/lib/python3.9/site-packages/torch/include -I/data1/home/lucky/anaconda3/envs/sugar/lib/python3.9/site-packages/torch/include/torch/csrc/api/include -I/data1/home/lucky/anaconda3/envs/sugar/lib/python3.9/site-packages/torch/include/TH -I/data1/home/lucky/anaconda3/envs/sugar/lib/python3.9/site-packages/torch/include/THC -I/opt/cuda/include -I/data1/home/lucky/anaconda3/envs/sugar/include/python3.9 -c cuda_rasterizer/backward.cu -o build/temp.linux-x86_64-cpython-39/cuda_rasterizer/backward.o -D__CUDA_NO_HALF_OPERATORS__ -D__CUDA_NO_HALF_CONVERSIONS__ -D__CUDA_NO_BFLOAT16_CONVERSIONS__ -D__CUDA_NO_HALF2_OPERATORS__ --expt-relaxed-constexpr --compiler-options '-fPIC' -I/data1/home/lucky/gaustudio/submodules/gaustudio-diff-gaussian-rasterization/third_party/glm/ -DTORCH_API_INCLUDE_EXTENSION_H -DPYBIND11_COMPILER_TYPE=\"_gcc\" -DPYBIND11_STDLIB=\"_libstdcpp\" -DPYBIND11_BUILD_ABI=\"_cxxabi1011\" -DTORCH_EXTENSION_NAME=_C -D_GLIBCXX_USE_CXX11_ABI=0 -gencode=arch=compute_89,code=compute_89 -gencode=arch=compute_89,code=sm_89 -std=c++17
      cuda_rasterizer/auxiliary.h(151): warning #177-D: variable "p_proj" was declared but never referenced
         float3 p_proj = { p_hom.x * p_w, p_hom.y * p_w, p_hom.z * p_w };
                ^
      
      Remark: The warnings can be suppressed with "-diag-suppress <warning-number>"
      
      /opt/cuda/bin/nvcc -I/data1/home/lucky/anaconda3/envs/sugar/lib/python3.9/site-packages/torch/include -I/data1/home/lucky/anaconda3/envs/sugar/lib/python3.9/site-packages/torch/include/torch/csrc/api/include -I/data1/home/lucky/anaconda3/envs/sugar/lib/python3.9/site-packages/torch/include/TH -I/data1/home/lucky/anaconda3/envs/sugar/lib/python3.9/site-packages/torch/include/THC -I/opt/cuda/include -I/data1/home/lucky/anaconda3/envs/sugar/include/python3.9 -c cuda_rasterizer/forward.cu -o build/temp.linux-x86_64-cpython-39/cuda_rasterizer/forward.o -D__CUDA_NO_HALF_OPERATORS__ -D__CUDA_NO_HALF_CONVERSIONS__ -D__CUDA_NO_BFLOAT16_CONVERSIONS__ -D__CUDA_NO_HALF2_OPERATORS__ --expt-relaxed-constexpr --compiler-options '-fPIC' -I/data1/home/lucky/gaustudio/submodules/gaustudio-diff-gaussian-rasterization/third_party/glm/ -DTORCH_API_INCLUDE_EXTENSION_H -DPYBIND11_COMPILER_TYPE=\"_gcc\" -DPYBIND11_STDLIB=\"_libstdcpp\" -DPYBIND11_BUILD_ABI=\"_cxxabi1011\" -DTORCH_EXTENSION_NAME=_C -D_GLIBCXX_USE_CXX11_ABI=0 -gencode=arch=compute_89,code=compute_89 -gencode=arch=compute_89,code=sm_89 -std=c++17
      cuda_rasterizer/auxiliary.h(151): warning #177-D: variable "p_proj" was declared but never referenced
         float3 p_proj = { p_hom.x * p_w, p_hom.y * p_w, p_hom.z * p_w };
                ^
      
      Remark: The warnings can be suppressed with "-diag-suppress <warning-number>"
      
      /opt/cuda/bin/nvcc -I/data1/home/lucky/anaconda3/envs/sugar/lib/python3.9/site-packages/torch/include -I/data1/home/lucky/anaconda3/envs/sugar/lib/python3.9/site-packages/torch/include/torch/csrc/api/include -I/data1/home/lucky/anaconda3/envs/sugar/lib/python3.9/site-packages/torch/include/TH -I/data1/home/lucky/anaconda3/envs/sugar/lib/python3.9/site-packages/torch/include/THC -I/opt/cuda/include -I/data1/home/lucky/anaconda3/envs/sugar/include/python3.9 -c cuda_rasterizer/rasterizer_impl.cu -o build/temp.linux-x86_64-cpython-39/cuda_rasterizer/rasterizer_impl.o -D__CUDA_NO_HALF_OPERATORS__ -D__CUDA_NO_HALF_CONVERSIONS__ -D__CUDA_NO_BFLOAT16_CONVERSIONS__ -D__CUDA_NO_HALF2_OPERATORS__ --expt-relaxed-constexpr --compiler-options '-fPIC' -I/data1/home/lucky/gaustudio/submodules/gaustudio-diff-gaussian-rasterization/third_party/glm/ -DTORCH_API_INCLUDE_EXTENSION_H -DPYBIND11_COMPILER_TYPE=\"_gcc\" -DPYBIND11_STDLIB=\"_libstdcpp\" -DPYBIND11_BUILD_ABI=\"_cxxabi1011\" -DTORCH_EXTENSION_NAME=_C -D_GLIBCXX_USE_CXX11_ABI=0 -gencode=arch=compute_89,code=compute_89 -gencode=arch=compute_89,code=sm_89 -std=c++17
      cuda_rasterizer/rasterizer_impl.h(24): error: namespace "std" has no member "uintptr_t"
          std::size_t offset = (reinterpret_cast<std::uintptr_t>(chunk) + alignment - 1) & ~(alignment - 1);
                                                      ^
      
      cuda_rasterizer/rasterizer_impl.h(40): error: identifier "uint32_t" is undefined
          uint32_t* point_offsets;
          ^
      
      cuda_rasterizer/rasterizer_impl.h(41): error: identifier "uint32_t" is undefined
          uint32_t* tiles_touched;
          ^
      
      cuda_rasterizer/rasterizer_impl.h(49): error: identifier "uint32_t" is undefined
          uint32_t* n_contrib;
          ^
      
      cuda_rasterizer/rasterizer_impl.h(58): error: identifier "uint64_t" is undefined
          uint64_t* point_list_keys_unsorted;
          ^
      
      cuda_rasterizer/rasterizer_impl.h(59): error: identifier "uint64_t" is undefined
          uint64_t* point_list_keys;
          ^
      
      cuda_rasterizer/rasterizer_impl.h(60): error: identifier "uint32_t" is undefined
          uint32_t* point_list_unsorted;
          ^
      
      cuda_rasterizer/rasterizer_impl.h(61): error: identifier "uint32_t" is undefined
          uint32_t* point_list;
          ^
      
      cuda_rasterizer/rasterizer_impl.cu(184): warning #549-D: variable "binning" is used before its value is set
         obtain(chunk, binning.point_list, P, 128);
                       ^
      
      Remark: The warnings can be suppressed with "-diag-suppress <warning-number>"
      
      8 errors detected in the compilation of "cuda_rasterizer/rasterizer_impl.cu".
      error: command '/opt/cuda/bin/nvcc' failed with exit code 2
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
  ERROR: Failed building wheel for gaustudio_diff_gaussian_rasterization
  Running setup.py clean for gaustudio_diff_gaussian_rasterization
Failed to build gaustudio_diff_gaussian_rasterization
ERROR: Could not build wheels for gaustudio_diff_gaussian_rasterization, which is required to install pyproject.toml-based projects
```
The same error has been fixed in original gs: https://github.com/graphdeco-inria/diff-gaussian-rasterization/pull/49

gcc 13 changelog: https://gcc.gnu.org/gcc-13/porting_to.html#header-dep-changes
